### PR TITLE
Remove static package for generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider $(GO_PROJECT)/cmd/generator
+GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on


### PR DESCRIPTION
With #1, we moved to call generator binary with `go:generate` which also added `// +build generate` for generator main.go file. This causes `make run` or `make build` to fail with the following error:

```
package github.com/crossplane-contrib/provider-jet-exoscale/cmd/generator: build constraints exclude all Go files in /Users/luc/Development/provider-exoscale/cmd/generator
```

This PR fixes that by removing it from static packages.