### PR TITLE
makefile: remove crd cleaning as it is not needed anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,6 @@ cobertura:
 		grep -v zz_ | \
 		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
 
-crds.clean:
-	@$(INFO) cleaning generated CRDs
-	@find package/crds -name '*.yaml' -exec sed -i.sed -e '1,1d' {} \; || $(FAIL)
-	@find package/crds -name '*.yaml.sed' -delete || $(FAIL)
-	@$(OK) cleaned generated CRDs
-
-generate.done: crds.clean
-
 # Update the submodules, such as the common build scripts.
 submodules:
 	@git submodule sync

--- a/package/crds/null.template.jet.crossplane.io_resources.yaml
+++ b/package/crds/null.template.jet.crossplane.io_resources.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/template.jet.crossplane.io_providerconfigs.yaml
+++ b/package/crds/template.jet.crossplane.io_providerconfigs.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/template.jet.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/template.jet.crossplane.io_providerconfigusages.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
### Description of your changes

Per @hasheddan 's comment, the package manager doesn't need this cleanup anymore.

Closes #14 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
