### PR TITLE
Remove non existing make targes from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,6 @@ Build, push, and install:
 make all
 ```
 
-Build image:
-
-```console
-make image
-```
-
-Push image:
-
-```console
-make push
-```
-
 Build binary:
 
 ```console


### PR DESCRIPTION

### Description of your changes

The `image` and `push` make targets are not present anymore and should be removed from the Readme file

Fixes #19 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This is a Readme update, I made sure that the markdown it is still rendering correctly.

[contribution process]: https://git.io/fj2m9
