### PR TITLE
Document declarative installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `provider-jet-template` is a [Crossplane](https://crossplane.io/) provider that
 is built using [Terrajet](https://github.com/crossplane/terrajet) code
-generation tools and exposes XRM-conformant managed resources for the 
+generation tools and exposes XRM-conformant managed resources for the
 Template API.
 
 ## Getting Started
@@ -12,6 +12,13 @@ to the [latest release](https://github.com/crossplane-contrib/provider-jet-templ
 ```
 kubectl crossplane install provider crossplane/provider-jet-template:v0.1.0
 ```
+
+Alternatively, you can use declarative installation:
+```
+kubectl apply -f examples/install.yaml
+```
+
+Notice that in this example Provider resource is referencing ControllerConfig with debug enabled.
 
 You can see the API reference [here](https://doc.crds.dev/github.com/crossplane-contrib/provider-jet-template).
 

--- a/examples/install.yaml
+++ b/examples/install.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: jet-template-config
+  labels:
+    app: crossplane-provider-jet-template
+spec:
+  image: crossplane/provider-jet-template-controller:v0.1.0
+  args: ["-d"]
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-provider-jet-template
+spec:
+  package: crossplane/provider-jet-template:v0.1.0
+  controllerConfigRef:
+    name: jet-template-config


### PR DESCRIPTION
Signed-off-by: Yury Tsarev <yury@upbound.io>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR documents a declarative way of provider installation as a (more reliable) alternative to the imperative one with `kubectl`

Contributes to https://github.com/crossplane/crossplane/issues/3055

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Provided `examples/install.yaml` was tested multiple times with the actual provider installation assuming the obvious naming modification.

[contribution process]: https://git.io/fj2m9
